### PR TITLE
Display correct day of the week with negative UTC offset

### DIFF
--- a/root/portal/modules/portal_calendar.php
+++ b/root/portal/modules/portal_calendar.php
@@ -125,7 +125,7 @@ class portal_calendar_module
 		));
 
 		// output the days for the current month 
-		for($i=0; $i < $mini_cal_month_days;) 
+		for($i = 0; $i < $mini_cal_month_days;)
 		{
 			// is this the first day of the week?
 			if($mini_cal_count == $this->mini_cal_fdow)
@@ -577,9 +577,7 @@ class portal_calendar_module
 	**/
 	private function makeTimestamp($date) 
 	{
-		global $user;
-
-		$this->stamp = (empty($this->stamp)) ? strtotime($date) + $user->timezone + $user->dst : $this->stamp;
+		$this->stamp = (empty($this->stamp)) ? strtotime($date) : $this->stamp;
 		return ($this->stamp);
 	}
 
@@ -630,14 +628,14 @@ class portal_calendar_module
 		$this->dateDD = date("d", $this->stamp);
 		$this->daysMonth = date("t", $this->stamp);
 
-		for ($i=1; $i < $this->daysMonth + 1; $i++) 
+		for ($i = 1; $i < $this->daysMonth + 1; $i++)
 		{
-			$this->makeTimestamp("$i $this->ext_dateMM $this->dateYYYY");
+			$this->makeTimestamp("$i {$this->ext_dateMM} {$this->dateYYYY}");
 			$this->day[] = array(
-				"0" => "$i",
-				"1" => $this->dateMM,
-				"2" => $this->dateYYYY,
-				"3" => (date('w', $this->stamp))
+				'0' => "$i",
+				'1' => $this->dateMM,
+				'2' => $this->dateYYYY,
+				'3' => date('w', $this->stamp)
 				);
 		}
 	}


### PR DESCRIPTION
A duplicate subtraction of the UTC offset and DST time caused the creation
of an incorrect timestamp. In return this caused us to go back too far and
therefore moved us back one day.

Conflicts:
    root/portal/modules/portal_calendar.php
