### PR TITLE
[ticket/122] Correctly display days in calendar

### DIFF
--- a/root/styles/prosilver/template/portal/modules/calendar_side.html
+++ b/root/styles/prosilver/template/portal/modules/calendar_side.html
@@ -2,11 +2,11 @@
 <!-- IF minical.MODULE_ID eq $MODULE_ID -->
 <a id="minical{minical.MODULE_ID}" style="float: right;"></a>
 {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}	
-	<table width="100%" cellspacing="1">
+	<table style="width: 100%;">
 		<tr>
-			<td align="left" colspan="2"><!-- IF S_CONTENT_DIRECTION eq 'rtl' -->{minical.U_NEXT_MONTH}<!-- ELSE -->{minical.U_PREV_MONTH}<!-- ENDIF --></td>
-			<td colspan="3" align="center"><span class="genmed">{minical.L_MINI_CAL_MONTH}</span></td>
-			<td align="right" colspan="2"><!-- IF S_CONTENT_DIRECTION eq 'rtl' -->{minical.U_PREV_MONTH}<!-- ELSE -->{minical.U_NEXT_MONTH}<!-- ENDIF --></td>
+			<td style="text-align: left;" colspan="2"><!-- IF S_CONTENT_DIRECTION eq 'rtl' -->{minical.U_NEXT_MONTH}<!-- ELSE -->{minical.U_PREV_MONTH}<!-- ENDIF --></td>
+			<td colspan="3" style="text-align: center;"><span class="genmed">{minical.L_MINI_CAL_MONTH}</span></td>
+			<td style="text-align: right;" colspan="2"><!-- IF S_CONTENT_DIRECTION eq 'rtl' -->{minical.U_PREV_MONTH}<!-- ELSE -->{minical.U_NEXT_MONTH}<!-- ENDIF --></td>
 		</tr>
 		<tr>
 			<!-- IF minical.S_SUNDAY_FIRST -->
@@ -26,7 +26,7 @@
 		<!-- IF minical.mini_cal_row.MODULE_ID eq $MODULE_ID -->
 		<tr>
 			<!-- BEGIN mini_cal_days -->
-				<td class="row1" align="center"><span class="gensmall">{minical.mini_cal_row.mini_cal_days.MINI_CAL_DAY}</span></td>
+				<td style="width: 14%; text-align: center;"><span class="gensmall">{minical.mini_cal_row.mini_cal_days.MINI_CAL_DAY}</span></td>
 			<!-- END mini_cal_days -->
 		</tr>
 		<!-- ENDIF -->


### PR DESCRIPTION
Due to changes in handling the time the HTML is incorrectly created and
thus causes a <tr> for every day. This results in every day being on a new
line. Additionally, the calendar module is now HTML5 valid.

Fixes #122

B3P-122
