### PR TITLE
[ticket/134] Replace old _approved and _replies columns with replacements

### DIFF
--- a/root/portal/includes/functions.php
+++ b/root/portal/includes/functions.php
@@ -213,8 +213,9 @@ function phpbb_fetch_posts($module_id, $forum_from, $permissions, $number_of_pos
 			t.topic_attachment,
 			t.topic_views,
 			t.poll_title,
-			t.topic_replies,
-			t.topic_replies_real,
+			t.topic_posts_approved,
+			t.topic_posts_unapproved,
+			t.topic_posts_softdeleted,
 			t.topic_poster,
 			t.topic_type,
 			t.topic_status,
@@ -259,7 +260,7 @@ function phpbb_fetch_posts($module_id, $forum_from, $permissions, $number_of_pos
 		'WHERE' => $topic_type . '
 				' . $post_time . '
 				AND t.topic_status <> ' . ITEM_MOVED . '
-				AND t.topic_approved = 1
+				AND t.topic_visibility = 1
 				AND t.topic_moved_id = 0
 				' . $str_where,
 		'ORDER_BY' => $topic_order,
@@ -340,8 +341,8 @@ function phpbb_fetch_posts($module_id, $forum_from, $permissions, $number_of_pos
 			'icon_id'				=> $row['icon_id'],
 			'topic_status'			=> $row['topic_status'],
 			'forum_id'				=> $row['forum_id'],
-			'topic_replies'			=> $row['topic_replies'],
-			'topic_replies_real'	=> $row['topic_replies_real'],
+			'topic_replies'			=> $row['topic_posts_approved'] + $row['topic_posts_unapproved'] + $row['topic_posts_softdeleted'],
+			'topic_replies_real'	=> $row['topic_posts_approved'],
 			'topic_time'			=> $user->format_date($row['post_time']),
 			'topic_last_post_time'	=> $row['topic_last_post_time'],
 			'topic_title'			=> $row['topic_title'],

--- a/root/portal/modules/portal_announcements.php
+++ b/root/portal/modules/portal_announcements.php
@@ -134,7 +134,7 @@ class portal_announcements_module
 					FROM ' . TOPICS_TABLE . '
 					WHERE ((topic_type = ' . POST_GLOBAL . ')
 						OR topic_type = ' . POST_ANNOUNCE . ')
-						AND topic_approved = 1
+						AND topic_visibility = 1
 						AND topic_moved_id = 0
 						' . $post_time . '
 						' . $str_where;

--- a/root/portal/modules/portal_news.php
+++ b/root/portal/modules/portal_news.php
@@ -127,7 +127,7 @@ class portal_news_module
 				$sql = 'SELECT COUNT(topic_id) AS num_topics
 					FROM ' . TOPICS_TABLE . '
 					WHERE ' . $topic_type . '
-						AND topic_approved = 1
+						AND topic_visibility = ' . ITEM_APPROVED . '
 						AND topic_moved_id = 0
 						' . $str_where;
 					$result = $db->sql_query($sql);

--- a/root/portal/modules/portal_poll.php
+++ b/root/portal/modules/portal_poll.php
@@ -251,7 +251,7 @@ class portal_poll_module
 
 			$sql = 'SELECT t.poll_title, t.poll_start, t.topic_id,  t.topic_first_post_id, t.forum_id, t.poll_length, t.poll_vote_change, t.poll_max_options, t.topic_status, f.forum_status, p.bbcode_bitfield, p.bbcode_uid
 					FROM ' . TOPICS_TABLE . ' t, ' . POSTS_TABLE . ' p, ' . FORUMS_TABLE . " f
-					WHERE t.forum_id = f.forum_id AND t.topic_approved = 1 AND t.poll_start > 0
+					WHERE t.forum_id = f.forum_id AND t.topic_visibility = 1 AND t.poll_start > 0
 					{$where}
 					AND t.topic_moved_id = 0
 					AND p.post_id = t.topic_first_post_id

--- a/root/portal/modules/portal_recent.php
+++ b/root/portal/modules/portal_recent.php
@@ -93,7 +93,7 @@ class portal_recent_module
 		$sql = 'SELECT topic_title, forum_id, topic_id
 			FROM ' . TOPICS_TABLE . ' t
 			WHERE topic_status <> ' . FORUM_LINK . '
-				AND topic_approved = 1 
+				AND topic_visibility = ' . ITEM_APPROVED . '
 				AND (topic_type = ' . POST_ANNOUNCE . ' OR topic_type = ' . POST_GLOBAL . ')
 				AND topic_moved_id = 0
 				' . $sql_where . '' .  $forum_sql . '
@@ -119,8 +119,8 @@ class portal_recent_module
 		//
 		$sql = 'SELECT topic_title, forum_id, topic_id
 			FROM ' . TOPICS_TABLE . ' t
-			WHERE topic_approved = 1 
-				AND topic_replies >=' . $config['hot_threshold'] . '
+			WHERE topic_visibility = ' . ITEM_APPROVED . '
+				AND topic_posts_approved >' . $config['hot_threshold'] . '
 				AND topic_moved_id = 0
 				' . $sql_where . '' .  $forum_sql . '
 			ORDER BY topic_time DESC';
@@ -146,7 +146,7 @@ class portal_recent_module
 		$sql = 'SELECT topic_title, forum_id, topic_id
 			FROM ' . TOPICS_TABLE . ' t
 			WHERE topic_status <> ' . ITEM_MOVED . '
-				AND topic_approved = 1 
+				AND topic_visibility = ' . ITEM_APPROVED . '
 				AND topic_type = ' . POST_NORMAL . '
 				AND topic_moved_id = 0
 				' . $sql_where . '' .  $forum_sql . '


### PR DESCRIPTION
Due to softdelete in 3.1, these columns were replaced by newer ones.

Fixes  #134

B3P-134
