### PR TITLE
[ticket/172] Remove portal.php from export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,3 @@ travis/		export-ignore
 .travis.yml	export-ignore
 phpunit.xml.*	export-ignore
 README.md	export-ignore
-portal.php	export-ignore


### PR DESCRIPTION
The file no longer exists inside the repository and therefore there is no
need to ingore it during export. This prevented the portal from exporting
the needed language file portal.php during the creation of the zip
archive.

B3P-172

Fixed #172
Fixed #206
