### PR TITLE
[ticket/377] Align portal columns right-to-left in rtl languages

### DIFF
--- a/styles/prosilver/template/portal/portal_body.html
+++ b/styles/prosilver/template/portal/portal_body.html
@@ -72,7 +72,7 @@
 
 	<!-- [+] right module area -->
 		<!-- IF S_RIGHT_COLUMN -->
-		<div id="portal-right" style="width: {S_PORTAL_RIGHT_COLUMN}px; margin-left: -{S_PORTAL_RIGHT_COLUMN}px;">
+		<div id="portal-right" style="width: {S_PORTAL_RIGHT_COLUMN}px; margin-<!-- IF S_CONTENT_DIRECTION eq 'rtl' -->right<!-- ELSE -->left<!-- ENDIF -->: -{S_PORTAL_RIGHT_COLUMN}px;">
 			<!-- BEGIN modules_right -->
 				<!-- DEFINE $TEMPLATE_FILE = '{modules_right.TEMPLATE_FILE}' -->
 				<!-- DEFINE $IMAGE_SRC = '{modules_right.IMAGE_SRC}' -->

--- a/styles/prosilver/theme/portal.css
+++ b/styles/prosilver/theme/portal.css
@@ -281,10 +281,18 @@ a.portal-forumtitle {
 	float: left;
 }
 
+.rtl #portal-left, .rtl #portal-right {
+	float: right;
+}
+
 #portal-center-wrapper {
 	width: 100%;
 	float: left;
 	display: block;
+}
+
+.rtl #portal-center-wrapper {
+	float: right;
 }
 
 #portal-column-area {
@@ -294,6 +302,11 @@ a.portal-forumtitle {
 
 #portal-left {
 	margin-left: -100%;
+}
+
+.rtl #portal-left {
+	margin-right: -100%;
+	margin-left: 0;
 }
 
 /*


### PR DESCRIPTION
With the old table layout, the left columns always displayed on the right
in rtl languages and vice-versa for the left right column. This should be
changed back in the tableless layout.

Fixes #377 
