### PR TITLE
[ticket/544] Use dummy cache driver instead of replaced null driver

### DIFF
--- a/tests/unit/controller/main_test.php
+++ b/tests/unit/controller/main_test.php
@@ -41,7 +41,7 @@ class main_test extends \board3\portal\tests\testframework\database_test_case
 			$phpEx
 		);
 
-		$cache = new \phpbb\cache\driver\null();
+		$cache = new \phpbb\cache\driver\dummy();
 
 		$user = new \board3\portal\tests\mock\user();
 


### PR DESCRIPTION
Fixes #544 