### PR TITLE
Poll icon in all edited topics (news, announcements blocks) with phpBB 3.2

### DIFF
--- a/portal/fetch_posts.php
+++ b/portal/fetch_posts.php
@@ -651,10 +651,11 @@ class fetch_posts
 	 */
 	public function shorten_message($message, $bbcode_uid, $length)
 	{
-		if (class_exists('\Nickvergessen\TrimMessage\TrimMessage'))
+		if (class_exists('\Marc1706\TextShortener\Shortener'))
 		{
-			$trim = new \Nickvergessen\TrimMessage\TrimMessage($message, $bbcode_uid, $length);
-			$message = $trim->message();
+			$trim = new \Marc1706\TextShortener\Shortener();
+			$message = $trim->setText($message)
+				->shortenText($length);
 			unset($trim);
 		}
 

--- a/portal/fetch_posts.php
+++ b/portal/fetch_posts.php
@@ -205,7 +205,7 @@ class fetch_posts
 				t.topic_title,
 				t.topic_attachment,
 				t.topic_views,
-				t.poll_title,
+				t.poll_start,
 				t.topic_posts_approved,
 				t.topic_posts_unapproved,
 				t.topic_posts_softdeleted,
@@ -334,7 +334,7 @@ class fetch_posts
 			'user_id'				=> $row['user_id'],
 			'user_type'				=> $row['user_type'],
 			'user_colour'			=> $row['user_colour'],
-			'poll'					=> $this->get_setting_based_data($row['poll_title'], true, false),
+			'poll'					=> $this->get_setting_based_data($row['poll_start'], true, false),
 			'attachment'			=> $this->get_setting_based_data($row['topic_attachment'], true, false),
 			'topic_views'			=> $row['topic_views'],
 			'forum_name'			=> $row['forum_name'],
@@ -651,11 +651,10 @@ class fetch_posts
 	 */
 	public function shorten_message($message, $bbcode_uid, $length)
 	{
-		if (class_exists('\Marc1706\TextShortener\Shortener'))
+		if (class_exists('\Nickvergessen\TrimMessage\TrimMessage'))
 		{
-			$trim = new \Marc1706\TextShortener\Shortener();
-			$message = $trim->setText($message)
-				->shortenText($length);
+			$trim = new \Nickvergessen\TrimMessage\TrimMessage($message, $bbcode_uid, $length);
+			$message = $trim->message();
 			unset($trim);
 		}
 

--- a/styles/prosilver/template/portal/_block_config.html
+++ b/styles/prosilver/template/portal/_block_config.html
@@ -5,13 +5,13 @@
 <!-- DEFINE $LR_BLOCK_F_R = '</div></div><br class="portal-clear" />' -->
 
 <!-- Config for the center blocks //-->
-<!-- DEFINE $C_BLOCK_H_L = '<div class="forabg" role="row"><div class="inner"><ul class="topiclist"><li class="header"><dl class="icon"><dt>' -->
+<!-- DEFINE $C_BLOCK_H_L = '<div class="forabg" role="row"><div class="inner"><ul class="topiclist"><li class="header"><dl class="row-item"><dt>' -->
 <!-- DEFINE $C_BLOCK_H_R = '</dt><dd></dd></dl></li></ul>' -->
 <!-- DEFINE $C_BLOCK_F_L = ' ' -->
 <!-- DEFINE $C_BLOCK_F_R = '</div></div><br class="portal-clear" />' -->
 
 <!-- Config for compact blocks //-->
-<!-- DEFINE $CC_BLOCK_H_L = '<div class="forabg" role="row"><div class="inner"><ul class="topiclist"><li class="header"><dl class="icon">' -->
+<!-- DEFINE $CC_BLOCK_H_L = '<div class="forabg" role="row"><div class="inner"><ul class="topiclist"><li class="header"><dl class="row-item">' -->
 <!-- DEFINE $CC_BLOCK_H_R = '</dl></li></ul>' -->
 
 <!-- Images-URL //-->

--- a/styles/prosilver/template/portal/modules/announcements_center.html
+++ b/styles/prosilver/template/portal/modules/announcements_center.html
@@ -1,51 +1,61 @@
-{$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
-<!-- IF $S_POSTBODY_TOP --><div class="postbody portal-module-postbody"><!-- ENDIF -->
-<!-- BEGIN announcements -->
-<!-- IF announcements.MODULE_ID eq $MODULE_ID -->
-<!-- BEGIN center_row -->
-	<!-- IF announcements.center_row.S_NO_TOPICS  -->
-	<div class="post bg2">
-		<div class="inner">
-			<span><strong>{L_NO_ANNOUNCEMENTS}</strong></span>
-	<!-- ELSE -->
-	<div class="post <!-- IF announcements.center_row.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF --> portal-no-margin">
-		<div class="inner">
-			<h4 class="first"><a <!-- IF announcements.center_row.S_FIRST_ROW -->id="a_{$MODULE_ID}" <!-- ENDIF -->name="a_{$MODULE_ID}_{announcements.center_row.A_ID}"></a><!-- IF announcements.center_row.S_UNREAD_INFO --><a href="{announcements.center_row.U_VIEW_UNREAD}">{NEWEST_POST_IMG}</a><!-- ELSE --><a href="{announcements.center_row.U_LAST_COMMENTS}">{READ_POST_IMG}</a><!-- ENDIF --> {announcements.center_row.ATTACH_ICON_IMG} <!-- IF announcements.center_row.S_POLL --> <strong>{L_VIEW_TOPIC_POLL}{L_COLON} </strong><!-- ENDIF --><!-- IF announcements.center_row.TOPIC_ICON_IMG --><img src="{T_ICONS_PATH}{announcements.center_row.TOPIC_ICON_IMG}" width="{announcements.center_row.TOPIC_ICON_IMG_WIDTH}" height="{announcements.center_row.TOPIC_ICON_IMG_HEIGHT}" alt="" /> <!-- ENDIF --><a href="{announcements.center_row.U_VIEW_COMMENTS}"><strong>{announcements.center_row.TITLE}</strong></a></h4>
-			<!-- IF announcements.center_row.PAGINATION --><strong class="pagination"><span>{announcements.center_row.PAGINATION}</span></strong><!-- ENDIF -->
-			<ul class="linklist">
-				<li>{L_POSTED} {L_POST_BY_AUTHOR}{L_COLON} {announcements.center_row.POSTER_FULL} &raquo; {announcements.center_row.TIME}</li>
-				<li class="rightside"><!-- IF announcements.center_row.FORUM_NAME -->{L_FORUM}{L_COLON} <strong><a href="{announcements.center_row.U_VIEWFORUM}">{announcements.center_row.FORUM_NAME}</a></strong><!-- ELSE -->{L_GLOBAL_ANNOUNCEMENT}<!-- ENDIF --></li>
-			</ul>
-			<!-- IF not $S_POSTBODY_TOP --><div class="postbody portal-module-postbody"><!-- ENDIF -->
-				<div class="content">
-					<br />{announcements.center_row.TEXT}
-				</div>
-			<!-- IF announcements.center_row.S_HAS_ATTACHMENTS -->
-			<dl class="attachbox">
-				<dt>{L_ATTACHMENTS}</dt>
-				<!-- BEGIN attachment -->
-					<dd>{announcements.center_row.attachment.DISPLAY_ATTACHMENT}</dd>
-				<!-- END attachment -->
-			</dl>
-			<!-- ENDIF -->
-			<br class="portal-clear" />
-			<span class="portal-title-span">{L_TOPIC_VIEWS}{L_COLON} {announcements.center_row.TOPIC_VIEWS} &nbsp;&bull;&nbsp; <a href="{announcements.center_row.U_VIEW_COMMENTS}" title="{L_VIEW_COMMENTS}">{L_COMMENTS}{L_COLON} {announcements.center_row.REPLIES}</a> &nbsp;&bull;&nbsp; <a href="{announcements.center_row.U_POST_COMMENT}">{L_POST_REPLY}</a></span>
-			<span class="portal-read-all-link">{announcements.center_row.OPEN}<a href="{announcements.center_row.U_READ_FULL}">{announcements.center_row.L_READ_FULL}</a>{announcements.center_row.CLOSE}</span>
-			<div class="back2top"><a href="#wrap" class="top" title="{L_BACK_TO_TOP}">{L_BACK_TO_TOP}</a></div>
-			<!-- IF announcements.center_row.S_NOT_LAST --><br class="portal-clear" /><!-- ENDIF -->
-			<!-- IF announcements.center_row.S_LAST_ROW and (announcements.AP_PAGINATION or announcements.TOTAL_ANNOUNCEMENTS) -->
-				<hr class="dashed" />
-				<div class="pagination">
-					{announcements.TOTAL_ANNOUNCEMENTS}
-				<!-- IF announcements.AP_PAGE_NUMBER --><!-- IF announcements.AP_PAGINATION --> &bull; {announcements.AP_PAGE_NUMBER} &bull; {announcements.AP_PAGINATION}<!-- ELSE --> &bull; {announcements.AP_PAGE_NUMBER}<!-- ENDIF --><!-- ENDIF -->
-				</div>
-			<!-- ENDIF -->
-		<!-- IF not $S_POSTBODY_TOP --></div><!-- ENDIF -->
-		<!-- ENDIF -->
-		</div>
-	</div>
-<!-- END center_row -->
-<!-- ENDIF -->
-<!-- END announcements -->
-<!-- IF $S_POSTBODY_TOP --></div><!-- ENDIF -->
-{$C_BLOCK_F_L}{$C_BLOCK_F_R}
+    {$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
+    <!-- IF $S_POSTBODY_TOP --><div class="postbody portal-module-postbody"><!-- ENDIF -->
+    <!-- BEGIN announcements -->
+    <!-- IF announcements.MODULE_ID eq $MODULE_ID -->
+    <!-- BEGIN center_row -->
+       <!-- IF announcements.center_row.S_NO_TOPICS  -->
+       <div class="post bg2">
+          <div class="inner">
+             <span><strong>{L_NO_ANNOUNCEMENTS}</strong></span>
+       <!-- ELSE -->
+       <div class="post <!-- IF announcements.center_row.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF --> portal-no-margin">
+          <div class="inner">
+             <h4 class="first">
+                <a <!-- IF announcements.center_row.S_FIRST_ROW -->id="a_{$MODULE_ID}" <!-- ENDIF -->name="a_{$MODULE_ID}_{announcements.center_row.A_ID}"></a><!-- IF announcements.center_row.S_UNREAD_INFO --><a class="unread" href="{announcements.center_row.U_VIEW_UNREAD}" title="{postrow.MINI_POST}"><!-- ELSE --><a href="{announcements.center_row.U_LAST_COMMENTS}"><!-- ENDIF -->
+                   <i class="icon fa-file fa-fw <!-- IF announcements.center_row.S_UNREAD_INFO -->icon-red<!-- ELSE -->icon-lightgray<!-- ENDIF --> icon-md" aria-hidden="true"></i><span class="sr-only">{postrow.MINI_POST}</span>
+                </a>
+                   <a <!-- IF announcements.center_row.S_FIRST_ROW -->id="a_{$MODULE_ID}" <!-- ENDIF -->name="a_{$MODULE_ID}_{announcements.center_row.A_ID}"></a><!-- IF announcements.center_row.S_UNREAD_INFO --><a class="unread" href="{announcements.center_row.U_VIEW_UNREAD}" title="{postrow.MINI_POST}"><!-- ELSE --><a href="{announcements.center_row.U_LAST_COMMENTS}"></a><!-- ENDIF --><i class="icon fa-paperclip fa-fw" aria-hidden="true"></i> <!-- IF announcements.center_row.S_POLL --><i class="icon fa-bar-chart fa-fw" aria-hidden="true"></i> <!-- ENDIF --><!-- IF announcements.center_row.TOPIC_ICON_IMG --><img src="{T_ICONS_PATH}{announcements.center_row.POST_ICON_IMG}" width="{announcements.center_row.POST_ICON_IMG_WIDTH}" height="{announcements.center_row.POST_ICON_IMG_HEIGHT}" alt="" /> <!-- ENDIF --><a href="{announcements.center_row.U_VIEW_COMMENTS}"><strong>{announcements.center_row.TITLE}</strong></a>
+             </h4>
+             <!-- IF announcements.center_row.PAGINATION --><strong class="pagination"><span>{announcements.center_row.PAGINATION}</span></strong><!-- ENDIF -->
+             <ul class="linklist">
+                <li>{L_POSTED} {L_POST_BY_AUTHOR}{L_COLON} {announcements.center_row.POSTER_FULL} &raquo; {announcements.center_row.TIME}</li>
+                <li class="rightside"><!-- IF announcements.center_row.FORUM_NAME -->{L_FORUM}{L_COLON} <strong><a href="{announcements.center_row.U_VIEWFORUM}">{announcements.center_row.FORUM_NAME}</a></strong><!-- ELSE -->{L_GLOBAL_ANNOUNCEMENT}<!-- ENDIF --></li>
+             </ul>
+             <!-- IF not $S_POSTBODY_TOP --><div class="postbody portal-module-postbody"><!-- ENDIF -->
+                <div class="content">
+                   <br />{announcements.center_row.TEXT}
+                </div>
+             <!-- IF announcements.center_row.S_HAS_ATTACHMENTS -->
+             <dl class="attachbox">
+                <dt>{L_ATTACHMENTS}</dt>
+                <!-- BEGIN attachment -->
+                   <dd>{announcements.center_row.attachment.DISPLAY_ATTACHMENT}</dd>
+                <!-- END attachment -->
+             </dl>
+             <!-- ENDIF -->
+             <br class="portal-clear" />
+             <span class="portal-title-span">{L_TOPIC_VIEWS}{L_COLON} {announcements.center_row.TOPIC_VIEWS} &nbsp;&bull;&nbsp; <a href="{announcements.center_row.U_VIEW_COMMENTS}" title="{L_VIEW_COMMENTS}">{L_COMMENTS}{L_COLON} {announcements.center_row.REPLIES}</a> &nbsp;&bull;&nbsp; <a href="{announcements.center_row.U_POST_COMMENT}">{L_POST_REPLY}</a></span>
+             <span class="portal-read-all-link">{announcements.center_row.OPEN}<a href="{announcements.center_row.U_READ_FULL}">{announcements.center_row.L_READ_FULL}</a>{announcements.center_row.CLOSE}</span>
+             <div class="back2top">
+                <a href="#top" class="top" title="{L_BACK_TO_TOP}">
+                   <i class="icon fa-chevron-circle-up fa-fw icon-gray" aria-hidden="true"></i>
+                   <span class="sr-only">{L_BACK_TO_TOP}</span>
+                </a>
+             </div>
+             <!-- IF announcements.center_row.S_NOT_LAST --><br class="portal-clear" /><!-- ENDIF -->
+             <!-- IF announcements.center_row.S_LAST_ROW and (announcements.AP_PAGINATION or announcements.TOTAL_ANNOUNCEMENTS) -->
+                <hr class="dashed" />
+                <div class="pagination">
+                   {announcements.TOTAL_ANNOUNCEMENTS}
+                <!-- IF announcements.AP_PAGE_NUMBER --><!-- IF announcements.AP_PAGINATION --> &bull; {announcements.AP_PAGE_NUMBER} &bull; {announcements.AP_PAGINATION}<!-- ELSE --> &bull; {announcements.AP_PAGE_NUMBER}<!-- ENDIF --><!-- ENDIF -->
+                </div>
+             <!-- ENDIF -->
+          <!-- IF not $S_POSTBODY_TOP --></div><!-- ENDIF -->
+          <!-- ENDIF -->
+          </div>
+       </div>
+    <!-- END center_row -->
+    <!-- ENDIF -->
+    <!-- END announcements -->
+    <!-- IF $S_POSTBODY_TOP --></div><!-- ENDIF -->
+    {$C_BLOCK_F_L}{$C_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/announcements_center.html
+++ b/styles/prosilver/template/portal/modules/announcements_center.html
@@ -1,8 +1,8 @@
-    {$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
-    <!-- IF $S_POSTBODY_TOP --><div class="postbody portal-module-postbody"><!-- ENDIF -->
-    <!-- BEGIN announcements -->
-    <!-- IF announcements.MODULE_ID eq $MODULE_ID -->
-    <!-- BEGIN center_row -->
+{$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
+<!-- IF $S_POSTBODY_TOP --><div class="postbody portal-module-postbody"><!-- ENDIF -->
+<!-- BEGIN announcements -->
+<!-- IF announcements.MODULE_ID eq $MODULE_ID -->
+<!-- BEGIN center_row -->
        <!-- IF announcements.center_row.S_NO_TOPICS  -->
        <div class="post bg2">
           <div class="inner">
@@ -54,8 +54,8 @@
           <!-- ENDIF -->
           </div>
        </div>
-    <!-- END center_row -->
-    <!-- ENDIF -->
-    <!-- END announcements -->
-    <!-- IF $S_POSTBODY_TOP --></div><!-- ENDIF -->
-    {$C_BLOCK_F_L}{$C_BLOCK_F_R}
+<!-- END center_row -->
+<!-- ENDIF -->
+<!-- END announcements -->
+<!-- IF $S_POSTBODY_TOP --></div><!-- ENDIF -->
+{$C_BLOCK_F_L}{$C_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/announcements_center_compact.html
+++ b/styles/prosilver/template/portal/modules/announcements_center_compact.html
@@ -22,33 +22,38 @@
 <ul class="topiclist topics responsive-portal-announcements">
 <!-- ENDIF -->
 	<li class="row<!-- IF announcements.center_row.S_ROW_COUNT is even --> bg1<!-- ELSE --> bg2<!-- ENDIF -->">
-		<dl class="icon {announcements.center_row.TOPIC_IMG_STYLE}">
-			<dt style="<!-- IF announcements.center_row.TOPIC_ICON_IMG -->background-image: url({T_ICONS_PATH}{announcements.center_row.TOPIC_ICON_IMG}); background-repeat: no-repeat;<!-- ENDIF -->" title="{announcements.center_row.TOPIC_FOLDER_IMG_ALT}">
-				<!-- IF announcements.center_row.S_UNREAD_TOPIC -->
-				<a href="{announcements.center_row.U_NEWEST_POST}">{NEWEST_POST_IMG}</a>
-				<!-- ENDIF -->
+		<dl class="row-item {announcements.center_row.TOPIC_IMG_STYLE}">
+			<dt style="<!-- IF announcements.center_row.TOPIC_ICON_IMG and S_TOPIC_ICONS -->background-image: url({T_ICONS_PATH}{announcements.center_row.TOPIC_ICON_IMG}); background-repeat: no-repeat;<!-- ENDIF -->" title="{announcements.center_row.TOPIC_FOLDER_IMG_ALT}">
+				<!-- IF announcements.center_row.S_UNREAD_INFO and not S_IS_BOT --><a href="{announcements.center_row.U_VIEW_UNREAD}" class="row-item-link"></a><!-- ENDIF -->
 				<div class="list-inner">
-					<!-- IF announcements.center_row.ATTACH_ICON_IMG -->{announcements.center_row.ATTACH_ICON_IMG} <!-- ENDIF -->
-					<!-- IF announcements.center_row.S_POLL --><strong>{L_VIEW_TOPIC_POLL}</strong><!-- ENDIF -->
-					<a href="{announcements.center_row.U_VIEW_COMMENTS}" title="{announcements.center_row.TITLE}" class="topictitle">{announcements.center_row.TITLE}</a>
-					<!-- IF U_VIEW_UNREAD_POST and not S_IS_BOT --> &bull; <a href="{U_VIEW_UNREAD_POST}">{L_VIEW_UNREAD_POST}</a> &bull; <!-- ENDIF -->
+							<a href="{announcements.center_row.U_VIEW_COMMENTS}" title="{announcements.center_row.TITLE}" class="topictitle">{announcements.center_row.TITLE}</a>
 					<!-- IF announcements.center_row.pagination -->
 					<div class="pagination">
+						<span><i class="icon fa-clone fa-fw" aria-hidden="true"></i></span>
 						<ul>
 							<!-- BEGIN pagination -->
 							<!-- IF announcements.center_row.pagination.S_IS_PREV -->
-							<!-- ELSEIF announcements.center_row.pagination.S_IS_CURRENT --><li><a href="{announcements.center_row.pagination.PAGE_URL}">{announcements.center_row.pagination.PAGE_NUMBER}</a></li>
+							<!-- ELSEIF announcements.center_row.pagination.S_IS_CURRENT --><li><a class="button" href="{announcements.center_row.pagination.PAGE_URL}">{announcements.center_row.pagination.PAGE_NUMBER}</a></li>
 							<!-- ELSEIF announcements.center_row.pagination.S_IS_ELLIPSIS --><li class="ellipsis"><span>{L_ELLIPSIS}</span></li>
 							<!-- ELSEIF announcements.center_row.pagination.S_IS_NEXT -->
-							<!-- ELSE --><li><a href="{announcements.center_row.pagination.PAGE_URL}">{announcements.center_row.pagination.PAGE_NUMBER}</a></li>
+							<!-- ELSE --><li><a class="button" href="{announcements.center_row.pagination.PAGE_URL}">{announcements.center_row.pagination.PAGE_NUMBER}</a></li>
 							<!-- ENDIF -->
 							<!-- END pagination -->
 						</ul>
 					</div>
 					<!-- ENDIF -->
-						<br />{L_POSTED} {L_POST_BY_AUTHOR} {announcements.center_row.POSTER_FULL} &raquo; {announcements.center_row.TIME}
+						<div class="responsive-show" style="display: none;">
+							{L_LAST_POST} {L_POST_BY_AUTHOR} {announcements.center_row.USERNAME_FULL_LAST} &raquo; <a href="{announcements.center_row.U_LAST_COMMENTS}" title="{L_GOTO_LAST_POST}" title="{L_VIEW_LATEST_POST}"> {announcements.center_row.LAST_POST_TIME}</a>
+						</div>
+
+						<div class="responsive-hide">
+							<!-- IF announcements.center_row.ATTACH_ICON_IMG --><i class="icon fa-paperclip fa-fw" aria-hidden="true"></i><!-- ENDIF -->
+							<!-- IF announcements.center_row.S_POLL --><i class="icon fa-bar-chart fa-fw" aria-hidden="true"></i><!-- ENDIF -->
+							{L_POST_BY_AUTHOR} {announcements.center_row.POSTER_FULL} &raquo; {announcements.center_row.TIME}
+						</div>
+					<!-- IF U_VIEW_UNREAD_POST and not S_IS_BOT --> &bull; <a href="{U_VIEW_UNREAD_POST}">{L_VIEW_UNREAD_POST}</a> &bull; <!-- ENDIF -->
 					<!-- IF announcements.center_row.FORUM_NAME -->
-						<br />{L_FORUM}{L_COLON} <a href="{announcements.center_row.U_VIEWFORUM}" class="portal-forumtitle">{announcements.center_row.FORUM_NAME}</a>
+						{L_FORUM}{L_COLON} <a href="{announcements.center_row.U_VIEWFORUM}" class="portal-forumtitle">{announcements.center_row.FORUM_NAME}</a>
 					<!-- ELSE -->
 						<br />{L_GLOBAL_ANNOUNCEMENT}
 					<!-- ENDIF -->
@@ -59,7 +64,7 @@
 				<dd class="posts">{announcements.center_row.REPLIES} <dfn>{L_REPLIES}</dfn></dd>
 				<dd class="views">{announcements.center_row.TOPIC_VIEWS} <dfn>{L_VIEWS}</dfn></dd>
 			<!-- ENDIF -->
-			<dd class="lastpost"><span><dfn>{L_LAST_POST}</dfn>{L_POST_BY_AUTHOR} {announcements.center_row.USERNAME_FULL_LAST} <!-- IF announcements.center_row.S_UNREAD_INFO --><a href="{announcements.center_row.U_VIEW_UNREAD}">{NEWEST_POST_IMG}</a><!-- ELSE --><a href="{announcements.center_row.U_LAST_COMMENTS}">{READ_POST_IMG}</a><!-- ENDIF --><br />
+			<dd class="lastpost"><span><dfn>{L_LAST_POST}</dfn>{L_POST_BY_AUTHOR} {announcements.center_row.USERNAME_FULL_LAST} <!-- IF announcements.center_row.S_UNREAD_INFO --><a href="{announcements.center_row.U_VIEW_UNREAD}" title="{L_VIEW_NEWEST_POST}"><i class="icon fa-external-link-square fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only">{L_VIEW_LATEST_POST}</span></a><!-- ELSE --><a href="{announcements.center_row.U_LAST_COMMENTS}" title="{L_VIEW_LATEST_POST}"><i class="icon fa-external-link-square fa-fw icon-lightgray icon-md" aria-hidden="true"></i><span class="sr-only">{L_VIEW_LATEST_POST}</span></a><!-- ENDIF --><br />
 				{announcements.center_row.LAST_POST_TIME}</span>
 			</dd>
 		</dl>

--- a/styles/prosilver/template/portal/modules/attachments_center.html
+++ b/styles/prosilver/template/portal/modules/attachments_center.html
@@ -4,7 +4,7 @@
 	<!-- IF .attach_center -->
 		<span class="portal-title-span"><strong>{L_FILENAME}</strong></span><br />
 		<!-- BEGIN attach_center -->
-			<span class="portal-title-span imageset icon_topic_attach">&nbsp;</span>&nbsp;<a class="portal-title-link" href="{attach_center.U_TOPIC}" title="{attach_center.REAL_FILENAME}"><strong>{attach_center.FILENAME}</strong></a><br class="portal-clear" />
+			<span class="portal-title-span icon fa-paperclip fa-fw" aria-hidden="true">&nbsp;</span>&nbsp;<a class="portal-title-link" href="{attach_center.U_TOPIC}" title="{attach_center.REAL_FILENAME}"><strong>{attach_center.FILENAME}</strong></a><br class="portal-clear" />
 			<span class="portal-text-span">{L_FILESIZE}{L_COLON}</span><span class="portal-data-span portal-gensmall"><strong>{attach_center.FILESIZE}</strong></span><br class="portal-clear" />
 			<span class="portal-text-span">{L_DOWNLOADS}{L_COLON}</span><span class="portal-data-span portal-gensmall"><strong>{attach_center.DOWNLOAD_COUNT}</strong></span><br class="portal-clear" />
 			<!-- IF not attach_center.S_LAST_ROW --><hr class="dashed" /><!-- ENDIF -->

--- a/styles/prosilver/template/portal/modules/attachments_side.html
+++ b/styles/prosilver/template/portal/modules/attachments_side.html
@@ -2,7 +2,7 @@
 	<!-- IF .attach_side -->
 		<span class="portal-title-span"><strong>{L_FILENAME}</strong></span><br />
 		<!-- BEGIN attach_side -->
-			<span class="portal-title-span portal-gensmall imageset icon_topic_attach">&nbsp;</span>&nbsp;<a class="portal-title-link" href="{attach_side.U_TOPIC}" title="{attach_side.REAL_FILENAME}"><strong>{attach_side.FILENAME}</strong></a><br class="portal-clear" />
+			<span class="portal-title-span portal-gensmall icon fa-paperclip fa-fw" aria-hidden="true">&nbsp;</span>&nbsp;<a class="portal-title-link" href="{attach_side.U_TOPIC}" title="{attach_side.REAL_FILENAME}"><strong>{attach_side.FILENAME}</strong></a><br class="portal-clear" />
 			<span class="portal-text-span">{L_FILESIZE}{L_COLON}</span><span class="portal-data-span portal-gensmall"><strong>{attach_side.FILESIZE}</strong></span><br class="portal-clear" />
 			<span class="portal-text-span">{L_DOWNLOADS}{L_COLON}</span><span class="portal-data-span portal-gensmall"><strong>{attach_side.DOWNLOAD_COUNT}</strong></span><br class="portal-clear" />
 			<!-- IF not attach_side.S_LAST_ROW --><hr class="dashed" /><!-- ENDIF -->

--- a/styles/prosilver/template/portal/modules/birthdays_side.html
+++ b/styles/prosilver/template/portal/modules/birthdays_side.html
@@ -20,7 +20,7 @@
 				<!-- IF BIRTHDAYS_AHEAD_LIST -->
 				<!-- BEGIN board3_birthday_ahead_list -->
 				<span class="portal-user-icon"></span>
-				<span class="portal-user-span">
+				<span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i>
 					<span title="{board3_birthday_ahead_list.DATE}">{board3_birthday_ahead_list.USER}</span>
 				</span>
 				<span class="portal-user-annotation">

--- a/styles/prosilver/template/portal/modules/calendar_side.html
+++ b/styles/prosilver/template/portal/modules/calendar_side.html
@@ -39,7 +39,7 @@
 		<!-- BEGIN cur_events -->
 
 		<li class="row">
-			<dl class="icon">
+			<dl class="row-item">
 				<dt class="portal-calendar-event-listing">
 					<!-- IF minical.cur_events.EVENT_URL --><a href="{minical.cur_events.EVENT_URL}" title="{minical.cur_events.EVENT_TITLE}" <!-- IF minical.cur_events.EVENT_URL_NEW_WINDOW -->onclick="window.open('{minical.cur_events.EVENT_URL}'); return false;"<!-- ENDIF -->><!-- ENDIF -->
 					<span class="portal-calendar-event-title">{minical.cur_events.EVENT_TITLE}{L_COLON}</span><br />
@@ -63,7 +63,7 @@
 		<!-- BEGIN upcoming_events -->
 
 		<li class="row">
-			<dl class="icon">
+			<dl class="row-item">
 				<dt class="portal-calendar-event-listing">
 					<!-- IF minical.upcoming_events.EVENT_URL --><a href="{minical.upcoming_events.EVENT_URL}" title="{minical.upcoming_events.EVENT_TITLE}" <!-- IF minical.upcoming_events.EVENT_URL_NEW_WINDOW -->onclick="window.open('{minical.upcoming_events.EVENT_URL}'); return false;"<!-- ENDIF -->><!-- ENDIF -->
 					<span class="portal-calendar-event-title">{minical.upcoming_events.EVENT_TITLE}{L_COLON}</span><br />

--- a/styles/prosilver/template/portal/modules/friends_side.html
+++ b/styles/prosilver/template/portal/modules/friends_side.html
@@ -9,7 +9,7 @@
 		<br class="portal-clear" />
 		<strong style="color:red<!-- IF S_CONTENT_DIRECTION eq 'rtl' -->; float: right;<!-- ENDIF -->">{L_FRIENDS_OFFLINE}</strong><br />
 	<!-- BEGIN b3p_friends_offline -->
-        <span class="portal-user-icon"></span><span class="portal-user-span">{b3p_friends_offline.USERNAME_FULL}</span><br class="portal-clear" />
+        <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i>{b3p_friends_offline.USERNAME_FULL}</span><br class="portal-clear" />
     <!-- BEGINELSE -->
         <span class="portal-user-span">{L_NO_FRIENDS_OFFLINE}</span>
     <!-- END b3p_friends_offline -->

--- a/styles/prosilver/template/portal/modules/jumpbox.html
+++ b/styles/prosilver/template/portal/modules/jumpbox.html
@@ -1,19 +1,19 @@
-    <!-- IF S_DISPLAY_JUMPBOX -->
-       <div class="jumpbox dropdown-container dropdown-container-right<!-- IF not S_IN_MCP --> dropdown-up<!-- ENDIF --> dropdown-{S_CONTENT_FLOW_BEGIN} dropdown-button-control" id="jumpbox">
-             <span title="<!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF -->" class="button button-secondary dropdown-trigger dropdown-select">
-                <span><!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF --></span>
-                <span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span>
-             </span>
-          <div class="dropdown">
-             <div class="pointer"><div class="pointer-inner"></div></div>
-             <ul class="dropdown-contents">
-                <!-- BEGIN jumpbox_forums -->
-                <!-- IF jumpbox_forums.FORUM_ID neq -1 -->
-                <li><a href="{jumpbox_forums.LINK}" class="<!-- IF jumpbox_forums.level -->jumpbox-sub-link<!-- ELSEIF jumpbox_forums.S_IS_CAT -->jumpbox-cat-link<!-- ELSE -->jumpbox-forum-link<!-- ENDIF -->"><!-- BEGIN level --><span class="spacer"></span><!-- END level --> <span><!-- IF jumpbox_forums.level --> &#8627; &nbsp;<!-- ENDIF --> {jumpbox_forums.FORUM_NAME}</span></a></li>
-                <!-- ENDIF -->
+<!-- IF S_DISPLAY_JUMPBOX -->
+   <div class="jumpbox dropdown-container dropdown-container-right<!-- IF not S_IN_MCP --> dropdown-up<!-- ENDIF --> dropdown-{S_CONTENT_FLOW_BEGIN} dropdown-button-control" id="jumpbox">
+         <span title="<!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF -->" class="button button-secondary dropdown-trigger dropdown-select">
+            <span><!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF --></span>
+            <span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span>
+         </span>
+      <div class="dropdown">
+         <div class="pointer"><div class="pointer-inner"></div></div>
+         <ul class="dropdown-contents">
+            <!-- BEGIN jumpbox_forums -->
+            <!-- IF jumpbox_forums.FORUM_ID neq -1 -->
+            <li><a href="{jumpbox_forums.LINK}" class="<!-- IF jumpbox_forums.level -->jumpbox-sub-link<!-- ELSEIF jumpbox_forums.S_IS_CAT -->jumpbox-cat-link<!-- ELSE -->jumpbox-forum-link<!-- ENDIF -->"><!-- BEGIN level --><span class="spacer"></span><!-- END level --> <span><!-- IF jumpbox_forums.level --> &#8627; &nbsp;<!-- ENDIF --> {jumpbox_forums.FORUM_NAME}</span></a></li>
+            <!-- ENDIF -->
                 <!-- END jumpbox_forums -->
-             </ul>
-          </div>
-       </div>
-    <br />
-    <!-- ENDIF -->
+         </ul>
+      </div>
+   </div>
+<br />
+<!-- ENDIF -->

--- a/styles/prosilver/template/portal/modules/jumpbox.html
+++ b/styles/prosilver/template/portal/modules/jumpbox.html
@@ -1,20 +1,19 @@
-<!-- IF S_DISPLAY_JUMPBOX -->
-	<form method="post" id="jumpbox" action="{S_JUMPBOX_ACTION}" onsubmit="if(document.jumpbox.f.value == -1){return false;}">
-
-	<!-- IF $CUSTOM_FIELDSET_CLASS -->
-		<fieldset class="{$CUSTOM_FIELDSET_CLASS}">
-	<!-- ELSE -->
-		<fieldset class="jumpbox">
-	<!-- ENDIF -->
-			<label for="f" accesskey="j"><!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF -->:</label>
-			<select name="f" id="f" onchange="if(this.options[this.selectedIndex].value != -1){ document.forms['jumpbox'].submit() }">
-			<!-- BEGIN jumpbox_forums -->
-				<!-- IF jumpbox_forums.S_FORUM_COUNT == 1 --><option value="-1">------------------</option><!-- ENDIF -->
-				<option value="{jumpbox_forums.FORUM_ID}"{jumpbox_forums.SELECTED}><!-- BEGIN level -->&nbsp; &nbsp;<!-- END level -->{jumpbox_forums.FORUM_NAME}</option>
-			<!-- END jumpbox_forums -->
-			</select>
-			<input type="submit" value="{L_GO}" class="button2" />
-		</fieldset>
-	</form>
-<br />
-<!-- ENDIF -->
+    <!-- IF S_DISPLAY_JUMPBOX -->
+       <div class="jumpbox dropdown-container dropdown-container-right<!-- IF not S_IN_MCP --> dropdown-up<!-- ENDIF --> dropdown-{S_CONTENT_FLOW_BEGIN} dropdown-button-control" id="jumpbox">
+             <span title="<!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF -->" class="button button-secondary dropdown-trigger dropdown-select">
+                <span><!-- IF S_IN_MCP and S_MERGE_SELECT -->{L_SELECT_TOPICS_FROM}<!-- ELSEIF S_IN_MCP -->{L_MODERATE_FORUM}<!-- ELSE -->{L_JUMP_TO}<!-- ENDIF --></span>
+                <span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span>
+             </span>
+          <div class="dropdown">
+             <div class="pointer"><div class="pointer-inner"></div></div>
+             <ul class="dropdown-contents">
+                <!-- BEGIN jumpbox_forums -->
+                <!-- IF jumpbox_forums.FORUM_ID neq -1 -->
+                <li><a href="{jumpbox_forums.LINK}" class="<!-- IF jumpbox_forums.level -->jumpbox-sub-link<!-- ELSEIF jumpbox_forums.S_IS_CAT -->jumpbox-cat-link<!-- ELSE -->jumpbox-forum-link<!-- ENDIF -->"><!-- BEGIN level --><span class="spacer"></span><!-- END level --> <span><!-- IF jumpbox_forums.level --> &#8627; &nbsp;<!-- ENDIF --> {jumpbox_forums.FORUM_NAME}</span></a></li>
+                <!-- ENDIF -->
+                <!-- END jumpbox_forums -->
+             </ul>
+          </div>
+       </div>
+    <br />
+    <!-- ENDIF -->

--- a/styles/prosilver/template/portal/modules/latest_members_side.html
+++ b/styles/prosilver/template/portal/modules/latest_members_side.html
@@ -1,8 +1,8 @@
-    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
        <span class="portal-user-span"><strong>{L_USERNAME}</strong></span>
        <span class="portal-user-annotation"><strong>{L_JOINED}</strong></span><br class="portal-clear" />
        <!-- BEGIN latest_members -->
           <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span>{latest_members.USERNAME_FULL}</span></span>
           <span class="portal-user-annotation">{latest_members.JOINED}</span><br class="portal-clear" />
        <!-- END latest_members -->
-    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/latest_members_side.html
+++ b/styles/prosilver/template/portal/modules/latest_members_side.html
@@ -1,8 +1,8 @@
-{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
-	<span class="portal-user-span"><strong>{L_USERNAME}</strong></span>
-	<span class="portal-user-annotation"><strong>{L_JOINED}</strong></span><br class="portal-clear" />
-	<!-- BEGIN latest_members -->
-		<span class="portal-user-icon"></span><span class="portal-user-span">{latest_members.USERNAME_FULL}</span>
-		<span class="portal-user-annotation">{latest_members.JOINED}</span><br class="portal-clear" />
-	<!-- END latest_members -->
-{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+       <span class="portal-user-span"><strong>{L_USERNAME}</strong></span>
+       <span class="portal-user-annotation"><strong>{L_JOINED}</strong></span><br class="portal-clear" />
+       <!-- BEGIN latest_members -->
+          <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span>{latest_members.USERNAME_FULL}</span></span>
+          <span class="portal-user-annotation">{latest_members.JOINED}</span><br class="portal-clear" />
+       <!-- END latest_members -->
+    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/leaders_ext_side.html
+++ b/styles/prosilver/template/portal/modules/leaders_ext_side.html
@@ -1,11 +1,11 @@
-{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
-	<!-- BEGIN group -->
-		<strong class="portal-user-span"><a href="{group.U_GROUP}" style="color: #{group.GROUP_COLOUR};" class="username-coloured">{group.GROUP_NAME}</a></strong><br class="portal-clear" />
-	<!-- BEGIN member -->
-		<span class="portal-user-icon"></span><span class="portal-user-span"><strong>{group.member.USERNAME_FULL}</strong></span><br class="portal-clear" />
-	<!-- END member -->
-	<br class="portal-clear" />
-	<!-- BEGINELSE -->
-		{L_NO_GROUPS_P}
-	<!-- END group -->
-{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+       <!-- BEGIN group -->
+          <strong class="portal-user-span"><a href="{group.U_GROUP}" style="color: #{group.GROUP_COLOUR};" class="username-coloured">{group.GROUP_NAME}</a></strong><br class="portal-clear" />
+       <!-- BEGIN member -->
+          <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span><strong>{group.member.USERNAME_FULL}</strong></span></span><br class="portal-clear" />
+       <!-- END member -->
+       <br class="portal-clear" />
+       <!-- BEGINELSE -->
+          {L_NO_GROUPS_P}
+       <!-- END group -->
+    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/leaders_ext_side.html
+++ b/styles/prosilver/template/portal/modules/leaders_ext_side.html
@@ -1,4 +1,4 @@
-    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
        <!-- BEGIN group -->
           <strong class="portal-user-span"><a href="{group.U_GROUP}" style="color: #{group.GROUP_COLOUR};" class="username-coloured">{group.GROUP_NAME}</a></strong><br class="portal-clear" />
        <!-- BEGIN member -->
@@ -8,4 +8,4 @@
        <!-- BEGINELSE -->
           {L_NO_GROUPS_P}
        <!-- END group -->
-    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/leaders_side.html
+++ b/styles/prosilver/template/portal/modules/leaders_side.html
@@ -1,15 +1,15 @@
-{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
-	<strong class="portal-user-span">{L_ADMINISTRATORS}</strong><br class="portal-clear" />
-	<!-- BEGIN b3p_admins -->
-		<span class="portal-user-icon"></span><span class="portal-user-span"><strong>{b3p_admins.USERNAME_FULL}</strong></span><br class="portal-clear" />
-	<!-- BEGINELSE -->
-		{L_NO_ADMINISTRATORS_P}<br /><br />
-	<!-- END b3p_admins -->
-	<br class="portal-clear" />
-	<strong class="portal-user-span">{L_MODERATORS}</strong><br class="portal-clear" />
-	<!-- BEGIN b3p_moderators -->
-		<span class="portal-user-icon"></span><span class="portal-user-span"><strong>{b3p_moderators.USERNAME_FULL}</strong></span><br class="portal-clear" />
-	<!-- BEGINELSE -->
-		{L_NO_MODERATORS_P}
-	<!-- END b3p_moderators -->
-{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+       <strong class="portal-user-span">{L_ADMINISTRATORS}</strong><br class="portal-clear" />
+       <!-- BEGIN b3p_admins -->
+          <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span><strong>{b3p_admins.USERNAME_FULL}</strong></span></span><br class="portal-clear" />
+       <!-- BEGINELSE -->
+          {L_NO_ADMINISTRATORS_P}<br /><br />
+       <!-- END b3p_admins -->
+       <br class="portal-clear" />
+       <strong class="portal-user-span">{L_MODERATORS}</strong><br class="portal-clear" />
+       <!-- BEGIN b3p_moderators -->
+          <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span><strong>{b3p_moderators.USERNAME_FULL}</strong></span></span><br class="portal-clear" />
+       <!-- BEGINELSE -->
+          {L_NO_MODERATORS_P}
+       <!-- END b3p_moderators -->
+    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/leaders_side.html
+++ b/styles/prosilver/template/portal/modules/leaders_side.html
@@ -1,4 +1,4 @@
-    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
        <strong class="portal-user-span">{L_ADMINISTRATORS}</strong><br class="portal-clear" />
        <!-- BEGIN b3p_admins -->
           <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span><strong>{b3p_admins.USERNAME_FULL}</strong></span></span><br class="portal-clear" />
@@ -12,4 +12,4 @@
        <!-- BEGINELSE -->
           {L_NO_MODERATORS_P}
        <!-- END b3p_moderators -->
-    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/links_side.html
+++ b/styles/prosilver/template/portal/modules/links_side.html
@@ -1,6 +1,6 @@
-    <!-- BEGIN portal_links -->
-    <!-- IF portal_links.MODULE_ID eq $MODULE_ID -->
-    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+<!-- BEGIN portal_links -->
+<!-- IF portal_links.MODULE_ID eq $MODULE_ID -->
+{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
        <div class="portal-navigation">
              <ul>
              <!-- BEGIN links -->
@@ -10,6 +10,6 @@
              <!-- END links -->
              </ul>
        </div>
-    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
-    <!-- ENDIF -->
-    <!-- END portal_links -->
+{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+<!-- ENDIF -->
+<!-- END portal_links -->

--- a/styles/prosilver/template/portal/modules/links_side.html
+++ b/styles/prosilver/template/portal/modules/links_side.html
@@ -1,15 +1,15 @@
-<!-- BEGIN portal_links -->
-<!-- IF portal_links.MODULE_ID eq $MODULE_ID -->
-{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
-	<div class="portal-navigation">
-			<ul>
-			<!-- BEGIN links -->
-				<li><a href="{portal_links.links.LINK_URL}" title="{portal_links.links.LINK_TITLE}" <!-- IF portal_links.links.NEW_WINDOW -->onclick="window.open('{portal_links.links.LINK_URL}'); return false;"<!-- ENDIF -->>{portal_links.links.LINK_TITLE}</a></li>
-			<!-- BEGINELSE -->
-				<span class="portal-title-span gensmall"><strong>{L_LINKS_NO_LINKS}</strong></span><br />
-			<!-- END links -->
-			</ul>
-	</div>
-{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
-<!-- ENDIF -->
-<!-- END portal_links -->
+    <!-- BEGIN portal_links -->
+    <!-- IF portal_links.MODULE_ID eq $MODULE_ID -->
+    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+       <div class="portal-navigation">
+             <ul>
+             <!-- BEGIN links -->
+                <li><a href="{portal_links.links.LINK_URL}" title="{portal_links.links.LINK_TITLE}" <!-- IF portal_links.links.NEW_WINDOW -->onclick="window.open('{portal_links.links.LINK_URL}'); return false;"<!-- ENDIF -->><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{portal_links.links.LINK_TITLE}</span></a></li>
+             <!-- BEGINELSE -->
+                <span class="portal-title-span gensmall"><strong>{L_LINKS_NO_LINKS}</strong></span><br />
+             <!-- END links -->
+             </ul>
+       </div>
+    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+    <!-- ENDIF -->
+    <!-- END portal_links -->

--- a/styles/prosilver/template/portal/modules/main_menu_side.html
+++ b/styles/prosilver/template/portal/modules/main_menu_side.html
@@ -2,20 +2,20 @@
 <!-- IF portal_menu.MODULE_ID eq $MODULE_ID -->
 {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
 	<div class="portal-navigation" role="menu">
-	<!-- BEGIN category -->
-		<div class="menutitle">{portal_menu.category.CAT_TITLE}</div>
-			<ul>
-			<!-- BEGIN links -->
-				<li><a href="{portal_menu.category.links.LINK_URL}" role="menuitem" <!-- IF portal_menu.category.links.NEW_WINDOW -->onclick="window.open('{portal_menu.category.links.LINK_URL}'); return false;"<!-- ENDIF -->>{portal_menu.category.links.LINK_TITLE}</a></li>
-			<!-- END links -->
-			</ul>
-		<hr class="dashed" />
-	<!-- BEGINELSE -->
-		<ul>
-			<li><span class="portal-title-span gensmall"><strong>{L_MENU_NO_LINKS}</strong></span><br /></li>
-		</ul>
-	<!-- END category -->
-	</div>
+   <!-- BEGIN category -->
+      <div class="menutitle">{portal_menu.category.CAT_TITLE}</div>
+         <ul>
+         <!-- BEGIN links -->
+            <li><a href="{portal_menu.category.links.LINK_URL}" role="menuitem" <!-- IF portal_menu.category.links.NEW_WINDOW -->onclick="window.open('{portal_menu.category.links.LINK_URL}'); return false;"<!-- ENDIF -->><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{portal_menu.category.links.LINK_TITLE}</span></a></li>
+         <!-- END links -->
+         </ul>
+      <hr class="dashed" />
+   <!-- BEGINELSE -->
+      <ul>
+         <li><span class="portal-title-span gensmall"><strong>{L_MENU_NO_LINKS}</strong></span><br /></li>
+      </ul>
+   <!-- END category -->
+   </div>
 {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
 <!-- ENDIF -->
 <!-- END portal_menu -->

--- a/styles/prosilver/template/portal/modules/news_compact_center.html
+++ b/styles/prosilver/template/portal/modules/news_compact_center.html
@@ -22,31 +22,37 @@
 <ul class="topiclist topics responsive-portal-news">
 <!-- ENDIF -->
 	<li class="row<!-- IF news.news_row.S_ROW_COUNT is even --> bg1<!-- ELSE --> bg2<!-- ENDIF -->">
-		<dl class="icon {news.news_row.TOPIC_IMG_STYLE}">
-			<dt <!-- IF news.news_row.TOPIC_ICON_IMG -->style="background-image: url({T_ICONS_PATH}{news.news_row.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{news.news_row.TOPIC_FOLDER_IMG_ALT}">
-				<!-- IF news.news_row.S_UNREAD_TOPIC -->
-				<a href="{news.news_row.U_NEWEST_POST}">{NEWEST_POST_IMG}</a>
-				<!-- ENDIF -->
+		<dl class="row-item {news.news_row.TOPIC_IMG_STYLE}">
+				<dt<!-- IF news.news_row.TOPIC_ICON_IMG and S_TOPIC_ICONS --> style="background-image: url({T_ICONS_PATH}{news.news_row.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{news.news_row.TOPIC_FOLDER_IMG_ALT}">
+					<!-- IF news.news_row.S_UNREAD_INFO and not S_IS_BOT --><a href="{news.news_row.U_VIEW_UNREAD}" class="row-item-link"></a><!-- ENDIF -->
 				<div class="list-inner">
-					<!-- IF news.news_row.ATTACH_ICON_IMG -->{news.news_row.ATTACH_ICON_IMG} <!-- ENDIF -->
 					<a href="{news.news_row.U_VIEW_COMMENTS}" title="{news.news_row.TITLE}" class="topictitle">{news.news_row.TITLE}</a><!-- IF U_VIEW_UNREAD_POST and not S_IS_BOT --> &bull; <a href="{U_VIEW_UNREAD_POST}">{L_VIEW_UNREAD_POST}</a> &bull; <!-- ENDIF -->
 					<!-- IF news.news_row.pagination -->
 					<div class="pagination">
+						<span><i class="icon fa-clone fa-fw" aria-hidden="true"></i></span>
 						<ul>
 						<!-- BEGIN pagination -->
 								<!-- IF news.news_row.pagination.S_IS_PREV -->
-								<!-- ELSEIF news.news_row.pagination.S_IS_CURRENT --><li><a href="{news.news_row.pagination.PAGE_URL}">{news.news_row.pagination.PAGE_NUMBER}</a></li>
+								<!-- ELSEIF news.news_row.pagination.S_IS_CURRENT --><li><a class="button" href="{news.news_row.pagination.PAGE_URL}">{news.news_row.pagination.PAGE_NUMBER}</a></li>
 								<!-- ELSEIF news.news_row.pagination.S_IS_ELLIPSIS --><li class="ellipsis"><span>{L_ELLIPSIS}</span></li>
 								<!-- ELSEIF news.news_row.pagination.S_IS_NEXT -->
-								<!-- ELSE --><li><a href="{news.news_row.pagination.PAGE_URL}">{news.news_row.pagination.PAGE_NUMBER}</a></li>
+								<!-- ELSE --><li><a class="button" href="{news.news_row.pagination.PAGE_URL}">{news.news_row.pagination.PAGE_NUMBER}</a></li>
 								<!-- ENDIF -->
 						<!-- END pagination -->
 						</ul>
 					</div>
 					<!-- ENDIF -->
-						<br />{L_POSTED} {L_POST_BY_AUTHOR} {news.news_row.POSTER_FULL} &raquo; {news.news_row.TIME}
+						<div class="responsive-show" style="display: none;">
+							{L_LAST_POST} {L_POST_BY_AUTHOR} {news.news_row.USERNAME_FULL_LAST} &raquo; <a href="{news.news_row.U_LAST_COMMENTS}" title="{L_GOTO_LAST_POST}" title="{L_VIEW_LATEST_POST}"> {news.news_row.LAST_POST_TIME}</a>
+						</div>
+
+						<div class="responsive-hide">
+							<!-- IF news.news_row.ATTACH_ICON_IMG --><i class="icon fa-paperclip fa-fw" aria-hidden="true"></i><!-- ENDIF -->
+							<!-- IF news.news_row.S_POLL --> <i class="icon fa-bar-chart fa-fw" aria-hidden="true"></i> <!-- ENDIF -->
+							{L_POST_BY_AUTHOR} {news.news_row.POSTER_FULL} &raquo; {news.news_row.TIME}
+						</div>
 					<!-- IF news.news_row.FORUM_NAME -->
-						<br />{L_FORUM}{L_COLON} <a href="{news.news_row.U_VIEWFORUM}" class="portal-forumtitle">{news.news_row.FORUM_NAME}</a>
+						{L_FORUM}{L_COLON} <a href="{news.news_row.U_VIEWFORUM}" class="portal-forumtitle">{news.news_row.FORUM_NAME}</a>
 					<!-- ENDIF -->
 					<!-- IF not news.S_DISPLAY_NEWS_RVS --><!-- IF news.news_row.FORUM_NAME -->&bull; <!-- ENDIF -->{L_REPLIES}{L_COLON} <strong>{news.news_row.REPLIES}</strong>  &bull; {L_VIEWS}{L_COLON} <strong>{news.news_row.TOPIC_VIEWS}</strong><!-- ENDIF -->
 				</div> <!-- \END <div class="list-inner"> -->
@@ -55,7 +61,7 @@
 				<dd class="posts" data-skip-responsive="true">{news.news_row.REPLIES} <dfn>{L_REPLIES}</dfn></dd>
 				<dd class="views" data-skip-responsive="true">{news.news_row.TOPIC_VIEWS} <dfn>{L_VIEWS}</dfn></dd>
 			<!-- ENDIF -->
-			<dd class="lastpost"><span><dfn>{L_LAST_POST}</dfn>{L_POST_BY_AUTHOR} {news.news_row.USERNAME_FULL_LAST} <!-- IF news.news_row.S_UNREAD_INFO --><a href="{news.news_row.U_VIEW_UNREAD}">{NEWEST_POST_IMG}</a><!-- ELSE --><a href="{news.news_row.U_LAST_COMMENTS}">{READ_POST_IMG}</a><!-- ENDIF --><br />
+			<dd class="lastpost"><span><dfn>{L_LAST_POST}</dfn>{L_POST_BY_AUTHOR} {news.news_row.USERNAME_FULL_LAST} <!-- IF news.news_row.S_UNREAD_INFO --><a href="{news.news_row.U_VIEW_UNREAD}" title="{L_VIEW_NEWEST_POST}"><i class="icon fa-external-link-square fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only">{L_VIEW_LATEST_POST}</span></a><!-- ELSE --><a href="{news.news_row.U_LAST_COMMENTS}" title="{L_VIEW_LATEST_POST}"><i class="icon fa-external-link-square fa-fw icon-lightgray icon-md" aria-hidden="true"></i><span class="sr-only">{L_VIEW_LATEST_POST}</span></a><!-- ENDIF --><br />
 				{news.news_row.LAST_POST_TIME}</span>
 			</dd>
 		</dl>
@@ -65,6 +71,7 @@
 		<li class="row<!-- IF news.news_row.S_ROW_COUNT is even --> bg2<!-- ELSE --> bg1<!-- ENDIF --> portal-news-pagination">
 			<div class="topic-actions">
 				<div class="pagination">
+					<span><i class="icon fa-clone fa-fw" aria-hidden="true"></i></span>
 					{news.TOTAL_NEWS}
 					<!-- IF news.NP_PAGE_NUMBER --><!-- IF news.NP_PAGINATION --> &bull; {news.NP_PAGE_NUMBER} &bull; {news.NP_PAGINATION}<!-- ELSE --> &bull; {news.NP_PAGE_NUMBER}<!-- ENDIF --><!-- ENDIF --> &nbsp;
 				</div>

--- a/styles/prosilver/template/portal/modules/recent_center.html
+++ b/styles/prosilver/template/portal/modules/recent_center.html
@@ -1,52 +1,52 @@
-<!-- IF .latest_announcements or .latest_hot_topics or .latest_topics -->
-{$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
-<div class="panel bg1 portal-no-margin">
-	<div class="inner">
-	<div class="portal-navigation">
-	<ul class="topiclist bg1">
-		<li><dl><dt></dt>
-			<dd class="portal-responsive-show portal-module-postbody portal-whois-online-content">
-			<table class="portal-module-postbody">
-			<tr class="menutitle">
-				<!-- IF .latest_announcements --><td class="portal-responsive-hide"><strong>{L_PORTAL_RECENT_ANN}</strong></td><!-- ENDIF -->
-				<!-- IF .latest_hot_topics --><td class="portal-responsive-hide"><strong>{L_PORTAL_RECENT_HOT_TOPIC}</strong></td><!-- ENDIF -->
-				<!-- IF .latest_topics --><td><strong>{L_PORTAL_RECENT_TOPIC}</strong></td><!-- ENDIF -->
-			</tr>
-			<tr>
-				<!-- IF .latest_announcements -->
-				<td class="row1 portal-responsive-hide portal-recent-column">
-					<span class="gensmall">
-					<!-- BEGIN latest_announcements -->
-								<a href="{latest_announcements.U_VIEW_TOPIC}" title="{latest_announcements.FULL_TITLE}">{latest_announcements.TITLE}</a>
-					<!-- END latest_announcements -->
-					</span>
-				</td>
-				<!-- ENDIF -->
-				<!-- IF .latest_hot_topics -->
-				<td class="row1 portal-responsive-hide portal-recent-column">
-					<span class="gensmall">
-					<!-- BEGIN latest_hot_topics -->
-						<a href="{latest_hot_topics.U_VIEW_TOPIC}" title="{latest_hot_topics.FULL_TITLE}">{latest_hot_topics.TITLE}</a>
-					<!-- END latest_hot_topics -->
-					</span>
-				</td>
-				<!-- ENDIF -->
-				<!-- IF .latest_topics -->
-				<td class="row1 portal-recent-column">
-					<span class="gensmall">
-					<!-- BEGIN latest_topics -->
-						<a href="{latest_topics.U_VIEW_TOPIC}" title="{latest_topics.FULL_TITLE}">{latest_topics.TITLE}</a>
-					<!-- END latest_topics -->
-					</span>
-				</td>
-				<!-- ENDIF -->
-			</tr>
-			</table>
-			</dd>
-		</dl></li>
-	</ul>
-	</div>
-	</div>
-</div>
-{$C_BLOCK_F_L}{$C_BLOCK_F_R}
-<!-- ENDIF -->
+    <!-- IF .latest_announcements or .latest_hot_topics or .latest_topics -->
+    {$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
+    <div class="panel bg1 portal-no-margin">
+       <div class="inner">
+       <div class="portal-navigation">
+       <ul class="topiclist bg1">
+          <li><dl><dt></dt>
+             <dd class="portal-responsive-show portal-module-postbody portal-whois-online-content">
+             <table class="portal-module-postbody">
+             <tr class="menutitle">
+                <!-- IF .latest_announcements --><td class="portal-responsive-hide"><strong>{L_PORTAL_RECENT_ANN}</strong></td><!-- ENDIF -->
+                <!-- IF .latest_hot_topics --><td class="portal-responsive-hide"><strong>{L_PORTAL_RECENT_HOT_TOPIC}</strong></td><!-- ENDIF -->
+                <!-- IF .latest_topics --><td><strong>{L_PORTAL_RECENT_TOPIC}</strong></td><!-- ENDIF -->
+             </tr>
+             <tr>
+                <!-- IF .latest_announcements -->
+                <td class="row1 portal-responsive-hide portal-recent-column">
+                   <span class="gensmall">
+                   <!-- BEGIN latest_announcements -->
+                            <a href="{latest_announcements.U_VIEW_TOPIC}" title="{latest_announcements.FULL_TITLE}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{latest_announcements.TITLE}</span></a>
+                   <!-- END latest_announcements -->
+                   </span>
+                </td>
+                <!-- ENDIF -->
+                <!-- IF .latest_hot_topics -->
+                <td class="row1 portal-responsive-hide portal-recent-column">
+                   <span class="gensmall">
+                   <!-- BEGIN latest_hot_topics -->
+                      <a href="{latest_hot_topics.U_VIEW_TOPIC}" title="{latest_hot_topics.FULL_TITLE}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{latest_hot_topics.TITLE}</span></a>
+                   <!-- END latest_hot_topics -->
+                   </span>
+                </td>
+                <!-- ENDIF -->
+                <!-- IF .latest_topics -->
+                <td class="row1 portal-recent-column">
+                   <span class="gensmall">
+                   <!-- BEGIN latest_topics -->
+                      <a href="{latest_topics.U_VIEW_TOPIC}" title="{latest_topics.FULL_TITLE}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{latest_topics.TITLE}</span></a>
+                   <!-- END latest_topics -->
+                   </span>
+                </td>
+                <!-- ENDIF -->
+             </tr>
+             </table>
+             </dd>
+          </dl></li>
+       </ul>
+       </div>
+       </div>
+    </div>
+    {$C_BLOCK_F_L}{$C_BLOCK_F_R}
+    <!-- ENDIF -->

--- a/styles/prosilver/template/portal/modules/recent_center.html
+++ b/styles/prosilver/template/portal/modules/recent_center.html
@@ -1,6 +1,6 @@
-    <!-- IF .latest_announcements or .latest_hot_topics or .latest_topics -->
-    {$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
-    <div class="panel bg1 portal-no-margin">
+<!-- IF .latest_announcements or .latest_hot_topics or .latest_topics -->
+{$C_BLOCK_H_L}{$TITLE}{$C_BLOCK_H_R}
+<div class="panel bg1 portal-no-margin">
        <div class="inner">
        <div class="portal-navigation">
        <ul class="topiclist bg1">
@@ -47,6 +47,6 @@
        </ul>
        </div>
        </div>
-    </div>
-    {$C_BLOCK_F_L}{$C_BLOCK_F_R}
-    <!-- ENDIF -->
+</div>
+{$C_BLOCK_F_L}{$C_BLOCK_F_R}
+<!-- ENDIF -->

--- a/styles/prosilver/template/portal/modules/topposters_side.html
+++ b/styles/prosilver/template/portal/modules/topposters_side.html
@@ -1,8 +1,8 @@
-    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
        <span class="portal-user-span"><strong>{L_USERNAME}</strong></span>
        <span class="portal-user-annotation"><strong>{L_POSTS}</strong></span><br class="portal-clear" />
        <!-- BEGIN topposters -->
           <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span>{topposters.USERNAME_FULL}</span></span>
           <span class="portal-user-annotation"><a href="{topposters.S_SEARCH_ACTION}">{topposters.POSTER_POSTS}</a></span><br class="portal-clear" />
        <!-- END topposters -->
-    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/topposters_side.html
+++ b/styles/prosilver/template/portal/modules/topposters_side.html
@@ -1,8 +1,8 @@
-{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
-	<span class="portal-user-span"><strong>{L_USERNAME}</strong></span>
-	<span class="portal-user-annotation"><strong>{L_POSTS}</strong></span><br class="portal-clear" />
-	<!-- BEGIN topposters -->
-		<span class="portal-user-icon"></span><span class="portal-user-span">{topposters.USERNAME_FULL}</span>
-		<span class="portal-user-annotation"><a href="{topposters.S_SEARCH_ACTION}">{topposters.POSTER_POSTS}</a></span><br class="portal-clear" />
-	<!-- END topposters -->
-{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+       <span class="portal-user-span"><strong>{L_USERNAME}</strong></span>
+       <span class="portal-user-annotation"><strong>{L_POSTS}</strong></span><br class="portal-clear" />
+       <!-- BEGIN topposters -->
+          <span class="portal-user-icon"></span><span class="portal-user-span"><i class="icon fa-user fa-fw" aria-hidden="true"></i><span>{topposters.USERNAME_FULL}</span></span>
+          <span class="portal-user-annotation"><a href="{topposters.S_SEARCH_ACTION}">{topposters.POSTER_POSTS}</a></span><br class="portal-clear" />
+       <!-- END topposters -->
+    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/user_menu_side.html
+++ b/styles/prosilver/template/portal/modules/user_menu_side.html
@@ -1,4 +1,4 @@
-    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
        <div class="portal-centered-content">
             {USERNAME_FULL}<br />
             <!-- IF B3P_AVATAR_IMG -->
@@ -42,4 +42,4 @@
                 <li><a href="{U_LOGIN_LOGOUT}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_LOGIN_LOGOUT}</span></a></li>
              </ul>
        </div>
-    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/template/portal/modules/user_menu_side.html
+++ b/styles/prosilver/template/portal/modules/user_menu_side.html
@@ -1,45 +1,45 @@
-{$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
-	<div class="portal-centered-content">
-        {USERNAME_FULL}<br />
-        <!-- IF B3P_AVATAR_IMG -->
-            <a href="{U_PROFILE}">{B3P_AVATAR_IMG}</a>
-        <!-- ELSEIF $NO_AVATAR_IMG -->
-            <a href="{U_PROFILE}"><img src="{T_THEME_PATH}{$NO_AVATAR_IMG}" alt="" /></a>
-        <!-- ENDIF -->
-        <!-- IF B3P_RANK_TITLE --><br /><span class="gensmall">{B3P_RANK_TITLE}</span><!-- ENDIF -->
-        <!-- IF B3P_RANK_IMG --><br />{B3P_RANK_IMG}<!-- ENDIF -->
-    </div> 
-	<hr class="dashed" />
-	<div class="portal-navigation">
-		<div class="menutitle">{L_M_MENU}</div>
-			<ul>
-				<!-- IF S_DISPLAY_SEARCH -->
-					<li><a href="{U_NEW_POSTS}">{L_NEW_POSTS}</a></li>
-					<li><a href="{U_UNREAD_POSTS}">{L_UNREAD_POSTS}</a></li>
-					<li><a href="{U_SELF_POSTS}">{L_SELF_POSTS}</a></li>
-				<!-- ENDIF -->
-				<!-- IF U_UM_BOOKMARKS -->
-					<li><a href="{U_UM_BOOKMARKS}">{L_UM_BOOKMARKS}</a></li>
-				<!-- ENDIF -->
-				<!-- IF S_DISPLAY_SUBSCRIPTIONS -->
-					<li><a href="{U_UM_MAIN_SUBSCRIBED}">{L_UM_MAIN_SUBSCRIBED}</a></li>
-				<!-- ENDIF -->
-				<!-- IF S_NOTIFICATIONS_DISPLAY -->
-				<li data-skip-responsive="true">
-					<a href="{U_VIEW_ALL_NOTIFICATIONS}"><span>{L_NOTIFICATIONS} [</span><strong>{NOTIFICATIONS_COUNT}</strong><span>]</span></a>
-				</li>
-				<!-- ENDIF -->
-				<!-- IF S_DISPLAY_PM -->
-					<li><a href="{U_PRIVATEMSGS}"><span>{L_PRIVATE_MESSAGES} [</span><strong>{PRIVATE_MESSAGE_COUNT}</strong><span>]</span></a></li>
-				<!-- ENDIF -->
-				<li><a href="{U_PROFILE}">{L_PROFILE}</a></li>
-				<!-- IF U_UM_MCP -->
-					<li><a href="{U_UM_MCP}">{L_MCP}</a></li>
-				<!-- ENDIF -->
-				<!-- IF U_ACP -->
-					<li><a href="{U_ACP}">{L_M_ACP}</a></li>
-				<!-- ENDIF -->
-				<li><a href="{U_LOGIN_LOGOUT}">{L_LOGIN_LOGOUT}</a></li>
-			</ul>
-	</div>
-{$LR_BLOCK_F_L}{$LR_BLOCK_F_R}
+    {$LR_BLOCK_H_L}<!-- IF $S_BLOCK_ICON --><img src="{$IMAGE_SRC}" width="{$IMAGE_WIDTH}" height="{$IMAGE_HEIGHT}" alt="" />&nbsp;<!-- ENDIF -->{$TITLE}{$LR_BLOCK_H_R}
+       <div class="portal-centered-content">
+            {USERNAME_FULL}<br />
+            <!-- IF B3P_AVATAR_IMG -->
+                <a href="{U_PROFILE}">{B3P_AVATAR_IMG}</a>
+            <!-- ELSEIF $NO_AVATAR_IMG -->
+                <a href="{U_PROFILE}"><img src="{T_THEME_PATH}{$NO_AVATAR_IMG}" alt="" /></a>
+            <!-- ENDIF -->
+            <!-- IF B3P_RANK_TITLE --><br /><span class="gensmall">{B3P_RANK_TITLE}</span><!-- ENDIF -->
+            <!-- IF B3P_RANK_IMG --><br />{B3P_RANK_IMG}<!-- ENDIF -->
+        </div>
+       <hr class="dashed" />
+       <div class="portal-navigation">
+          <div class="menutitle">{L_M_MENU}</div>
+             <ul>
+                <!-- IF S_DISPLAY_SEARCH -->
+                   <li><a href="{U_NEW_POSTS}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_NEW_POSTS}</span></a></li>
+                   <li><a href="{U_UNREAD_POSTS}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_UNREAD_POSTS}</span></a></li>
+                   <li><a href="{U_SELF_POSTS}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_SELF_POSTS}</span></a></li>
+                <!-- ENDIF -->
+                <!-- IF U_UM_BOOKMARKS -->
+                   <li><a href="{U_UM_BOOKMARKS}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_UM_BOOKMARKS}</span></a></li>
+                <!-- ENDIF -->
+                <!-- IF S_DISPLAY_SUBSCRIPTIONS -->
+                   <li><a href="{U_UM_MAIN_SUBSCRIBED}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_UM_MAIN_SUBSCRIBED}</span></a></li>
+                <!-- ENDIF -->
+                <!-- IF S_NOTIFICATIONS_DISPLAY -->
+                <li data-skip-responsive="true">
+                   <a href="{U_VIEW_ALL_NOTIFICATIONS}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_NOTIFICATIONS} [</span><strong>{NOTIFICATIONS_COUNT}</strong><span>]</span></a>
+                </li>
+                <!-- ENDIF -->
+                <!-- IF S_DISPLAY_PM -->
+                   <li><a href="{U_PRIVATEMSGS}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_PRIVATE_MESSAGES} [</span><strong>{PRIVATE_MESSAGE_COUNT}</strong><span>]</span></a></li>
+                <!-- ENDIF -->
+                <li><a href="{U_PROFILE}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_PROFILE}</span></a></li>
+                <!-- IF U_UM_MCP -->
+                   <li><a href="{U_UM_MCP}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_MCP}</span></a></li>
+                <!-- ENDIF -->
+                <!-- IF U_ACP -->
+                   <li><a href="{U_ACP}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_M_ACP}</span></a></li>
+                <!-- ENDIF -->
+                <li><a href="{U_LOGIN_LOGOUT}"><i class="icon fa-arrow-circle-o-right fa-fw" aria-hidden="true"></i><span>{L_LOGIN_LOGOUT}</span></a></li>
+             </ul>
+       </div>
+    {$LR_BLOCK_F_L}{$LR_BLOCK_F_R}

--- a/styles/prosilver/theme/portal.css
+++ b/styles/prosilver/theme/portal.css
@@ -122,6 +122,10 @@
 	min-height: 1em;
 }
 
+.content li {
+    list-style-type: inherit !important;
+}
+
 .portal-stylechanger-select {
 	width: 150px;
 }

--- a/styles/prosilver/theme/portal.css
+++ b/styles/prosilver/theme/portal.css
@@ -16,12 +16,8 @@
 }
 
 .portal-navigation ul li a{
-	background-image: url("./images/portal/arrowbullet.gif");
-	background-repeat: no-repeat;
-	background-position: center left; /*custom bullet list image*/
 	display: block;
 	padding: 2px 0;
-	padding-left: 19px; /*link text is indented 19px*/
 	font-weight: bold;
 	font-size: 90%;
 }
@@ -52,8 +48,6 @@
 }
 
 .portal-user-icon {
-	background-image: url("../../all/theme/images/portal/portal_user.png");
-	padding-left: 16px;
 	padding-top: 16px;
 	float: left;
 	margin-bottom: 2px;
@@ -61,22 +55,6 @@
 
 .rtl .portal-user-icon {
 	float: right;
-}
-
-.portal-arrow-left-icon {
-	background-image: url('../../all/theme/images/portal/cal_icon_left_arrow.png');
-	padding-left: 16px;
-	padding-top: 16px;
-	float: left;
-	margin-bottom: 2px;
-}
-
-.portal-arrow-right-icon {
-	background-image: url('../../all/theme/images/portal/cal_icon_right_arrow.png');
-	padding-left: 16px;
-	padding-top: 16px;
-	float: right;
-	margin-bottom: 2px;
 }
 
 .portal-user-span {
@@ -367,7 +345,7 @@ a.portal-forumtitle {
 }
 
 #portal-body .row .pagination {
-	padding: 1px 0 1px 12px;
+   margin: 1px 0 1px 12px;
 }
 
 #portal-body #viewpoll {
@@ -406,9 +384,6 @@ a.portal-forumtitle {
 
 /* RTL language fixes */
 .rtl .portal-navigation ul li a{
-	background-image: url("./images/portal/arrowbullet_rtl.gif");
-	background-position: center right; /* custom bullet list image */
-	padding-right: 19px; /* link text is indented 19px */
 	text-align: right;
 }
 
@@ -633,4 +608,9 @@ dd.responsive-portal-news:last-of-type, dd.responsive-portal-announcements:last-
 	.portal-clock-back-hours-down, .portal-clock-front-hours-down {
 		margin-left: -1px;
 	}
+}
+
+.fa-backward, .fa-forward {
+	font-size: 1.4em;
+	margin-bottom: 4px;
 }

--- a/styles/prosilver/theme/portal_all_responsive.css
+++ b/styles/prosilver/theme/portal_all_responsive.css
@@ -35,12 +35,6 @@
 	.portal-body-center dt { width: 100% !important; }
 }
 
-@media only screen and (max-width: 550px), only screen and (max-device-width: 550px) {
-	.portal-body-center ul.topiclist dt .list-inner {
-		margin-right: 0;
-	}
-}
-
 @media only screen and (max-width: 540px), only screen and (max-device-width: 540px) {
 	#portal-left, #portal-right {
 		display: none;


### PR DESCRIPTION
phpBB 3.2 seems to add `<td></td>` to all edited topics in the database poll question section. 
`phpbb_topics --> poll_title`
Therefore the poll icon is popping up in all edited topics, even without poll, in the news and announcements blocks.

A working fix in **fetch_posts.php** - replace `t.poll_title,` with `t.poll_start,`
