### PR TITLE
custom.php line 310 Send an integer instead of a string

### DIFF
--- a/modules/custom.php
+++ b/modules/custom.php
@@ -307,7 +307,7 @@ class custom extends module_base
 			default:
 				if (!isset($custom_code))
 				{
-					$custom_code = generate_text_for_edit($portal_config['board3_custom_' . $module_id . '_code'], $this->config['board3_custom_' . $module_id . '_uid'], '');
+					$custom_code = generate_text_for_edit($portal_config['board3_custom_' . $module_id . '_code'], $this->config['board3_custom_' . $module_id . '_uid'], 0);
 				}
 
 				$this->template->assign_vars(array(


### PR DESCRIPTION
Fix for the problem with blocks:
"if you make a custom block in acp then go to edit it you get this
[phpBB Debug] PHP Warning: in file [ROOT]/includes/functions_content.php on line 789: A non-numeric value encountered
[phpBB Debug] PHP Warning: in file [ROOT]/includes/functions_content.php on line 790: A non-numeric value encountered
[phpBB Debug] PHP Warning: in file [ROOT]/includes/functions_content.php on line 791: A non-numeric value encountered
php version 7.1
phpbb 3.2.5
portal version latest github version

block does work though and can be edited
error is only displayed in acp when editing the custom block"
https://github.com/board3/Board3-Portal/issues/711#issue-415859055

The Problem is mentioned here:
https://github.com/board3/Board3-Portal/issues/711#issuecomment-586791989

Change is made here
https://github.com/Sajaki/Board3-Portal/pull/3/files